### PR TITLE
 #11 Fix: You must not have more than one "auto_item" paramter

### DIFF
--- a/contao/classes/ImiMMChangeLanguageObserver.php
+++ b/contao/classes/ImiMMChangeLanguageObserver.php
@@ -108,6 +108,10 @@ class ImiMMChangeLanguageObserver
 	public function translateMMUrlsV3(
 		\Terminal42\ChangeLanguage\Event\ChangelanguageNavigationEvent $event
 	) {
+	    if (count($event->getUrlParameterBag()->getUrlAttributes()) > 0) {
+            return;
+        }
+
 		// The target root page for current event
 		$targetRoot = $event->getNavigationItem()->getRootPage();
 		$targetLanguage   = $targetRoot->language; // The target language
@@ -164,5 +168,6 @@ class ImiMMChangeLanguageObserver
 
 		// fallback - if we do not have any translated values: use untranslated alias
         $event->getUrlParameterBag()->setUrlAttribute('items', $alias);
+
 	}
 }

--- a/contao/config/autoload.ini
+++ b/contao/config/autoload.ini
@@ -2,6 +2,7 @@
 ; List modules which are required to be loaded beforehand
 ;;
 requires[] = "core"
+requires[] = "changelanguage"
 
 ;;
 ; Configure what you want the autoload creator to register


### PR DESCRIPTION
* We need to change load order to be loaded after the built in lang
switches
* Check if Auto Item is present, if yes: do nothing
* Update Documentation