### PR TITLE
Fixes problem with the  when using MetaModels with localized languages

### DIFF
--- a/contao/classes/ImiMMChangeLanguageObserver.php
+++ b/contao/classes/ImiMMChangeLanguageObserver.php
@@ -115,6 +115,9 @@ class ImiMMChangeLanguageObserver
 		// The target root page for current event
 		$targetRoot = $event->getNavigationItem()->getRootPage();
 		$targetLanguage   = $targetRoot->language; // The target language
+        // since metamodels supports localization in side the lanuages (e.g. de-AT), these language codes
+        // need to be converted from e.g. de-AT to de_AT when calling getTranslatedDataFor-method
+        $targetLanguage   = str_replace('-', '_', $targetLanguage);
 
         $factory = $this->getMMFactory();
 

--- a/contao/classes/ImiMMChangeLanguageObserver.php
+++ b/contao/classes/ImiMMChangeLanguageObserver.php
@@ -115,7 +115,7 @@ class ImiMMChangeLanguageObserver
 		// The target root page for current event
 		$targetRoot = $event->getNavigationItem()->getRootPage();
 		$targetLanguage   = $targetRoot->language; // The target language
-        // since metamodels supports localization in side the lanuages (e.g. de-AT), these language codes
+        // since metamodels supports localization inside the languages (e.g. de-AT), these language codes
         // need to be converted from e.g. de-AT to de_AT when calling getTranslatedDataFor-method
         $targetLanguage   = str_replace('-', '_', $targetLanguage);
 


### PR DESCRIPTION
Since metamodels supports localization inside the languages (e.g. de-AT), these language codes need to be converted from e.g. de-AT to de_AT when calling getTranslatedDataFor-method.